### PR TITLE
Fix: bump git version for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine as build
 
 WORKDIR /app
 
-RUN apk add --no-cache git=2.34.1-r0
+RUN apk add --no-cache git~=2.34.2
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --non-interactive && yarn cache clean
 COPY . .


### PR DESCRIPTION
Need to update git to resolve the following docker build error:
```shell
Step 3/20 : RUN apk add --no-cache git=2.34.1-r0
 ---> Running in a08f8ee73369
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  git-2.34.2-r0:
    breaks: world[git=2.34.1-r0]
The command '/bin/sh -c apk add --no-cache git=2.34.1-r0' returned a non-zero code: 1
```