### PR TITLE
fix: bump curl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV BASE_PATH=$BASE_PATH
 ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app
-RUN apk add --no-cache curl=7.80.0-r0
+RUN apk add --no-cache curl=7.80.0-r1
 COPY --from=build /app /app
 
 RUN mkdir -p /app/.next/cache/images && chown -R node:node /app/.next/cache/images


### PR DESCRIPTION
### Bump curl version

There is no previous curl version in Alpine's repository so have to bump