### PR TITLE
Added .github codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github @lidofinance/review-gh-workflows


### PR DESCRIPTION
# Overview

Due to [GitHub Repo Setup Policy](https://www.notion.so/GitHub-Repo-Setup-Policy-5a691299e22847a1a9397c04d7b3fd60) we need to add @lidofinance/review-gh-workflows as codeowners for .github folder