### PR TITLE
fix: page crush on empty vote

### DIFF
--- a/pages/vote/[voteId].tsx
+++ b/pages/vote/[voteId].tsx
@@ -1,12 +1,13 @@
 import { useRouter } from 'next/dist/client/router'
-
 import { VoteForm } from 'modules/votes/ui/VoteForm'
 
 export default function VotePage() {
   const router = useRouter()
-  const { voteId: urlVoteId = [] } = router.query
-  const [voteId] = urlVoteId as string[]
-
+  const { voteId } = router.query
+  if (!voteId || typeof voteId !== 'string') {
+    router.replace('/')
+    return null
+  }
   return <VoteForm voteId={voteId} />
 }
 


### PR DESCRIPTION
### Description

Removed `[[...voteIds]]` towards `[voteId]`. `/votes` now abides next default behavior and shows 404.

### Code review notes

I checked that this logic wasn't used in any way. But please have a look.


### Testing notes
Going to `/votes` without vote id will now return 404. 

### Checklist:

- [x]  Checked the changes locally.
