### PR TITLE
Support for additional contract proxy method in evm decoding pipeline

### DIFF
--- a/modules/votes/hooks/useEvmScriptDecoder.ts
+++ b/modules/votes/hooks/useEvmScriptDecoder.ts
@@ -88,6 +88,7 @@ export function useEVMScriptDecoder(): EVMScriptDecoder {
             ...abiProviders.middlewares.ProxyABIMiddleware
               .DefaultImplMethodNames,
             '__Proxy_implementation',
+            'proxy__getImplementation',
           ],
           loadImplAddress(proxyAddress, abiElement) {
             const contract = new Contract(


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Support for additional contract proxy method in evm decoding pipeline

### Testing notes

1. Disable checkbox on `Settings —> Use built-in ABIs` and click `Save`
2. Check votes
2.1 Vote #517 (Goerli); Step 2.1: call on StakingRouter should be parsed
2.2 Vote #159 (Mainnet); Step 2.1: call on StakingRouter should be parsed

Before/After

<img width="837" alt="image" src="https://github.com/lidofinance/dao-voting-ui/assets/7289992/6ecf6051-88cc-4383-aeff-8d1b5fd2639e">

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x]  Checked the changes locally.
