### PR TITLE
fix: csp for new alchemy domain name

### DIFF
--- a/modules/shared/utils/csp.ts
+++ b/modules/shared/utils/csp.ts
@@ -32,6 +32,7 @@ export const contentSecurityPolicy = {
       'https://api.thegraph.com',
       'https://*.infura.io',
       'https://*.alchemyapi.io',
+      'https://*.alchemy.com',
       'https://*.etherscan.io/api',
       ...trustedHosts,
     ],


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

CSP updated according recent alchemy api domain name changes.
It was `https://eth-{NETWORK}.alchemyapi.io/v2/{ALCHEMY_API_KEY}` before
and now it appears to be `https://eth-{NETWORK}.g.alchemy.com/v2/{ALCHEMY_API_KEY}`

### Checklist:

- [x]  Checked the changes locally.
