### PR TITLE
fix: added another domain for ipfs description

### DIFF
--- a/modules/shared/utils/csp.ts
+++ b/modules/shared/utils/csp.ts
@@ -35,7 +35,7 @@ export const contentSecurityPolicy = {
       'https://*.alchemy.com',
       'https://*.etherscan.io/api',
       'https://*.ipfs.w3s.link',
-      'https://cloudflare-ipfs.com/ipfs/',
+      'https://*.ipfs.dweb.link',
       ...trustedHosts,
     ],
     prefetchSrc: ["'self'", ...trustedHosts],


### PR DESCRIPTION
 added another domain for ipfs description and remove domain for external ipfs links

### Description

Added another domain for ipfs description and remove domain for external ipfs links

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
