### PR TITLE
fix: change link display type to avoid collapse with other text

### DIFF
--- a/modules/shared/ui/Common/ExternalLink/ExternalLinkStyle.ts
+++ b/modules/shared/ui/Common/ExternalLink/ExternalLinkStyle.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 export const ExternalLinkWrap = styled.span`
-  display: inline-block;
+  display: inline;
   height: ${({ theme }) => theme.spaceMap.lg}px;
   width: fit-content;
   color: var(--lido-color-primary);


### PR DESCRIPTION
### Description

Change link type 

### Demo (before/after)

<img src="https://github.com/lidofinance/dao-voting-ui/assets/3354239/c965378e-e265-49d0-bdef-198e675aae42" width=49% />
<img src="https://github.com/lidofinance/dao-voting-ui/assets/3354239/8d826506-9473-4b88-9173-61c389544bd7" width=49% />

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
