### PR TITLE
fix: open home page if vote input hitted by enter button with empty value

### DIFF
--- a/modules/shared/ui/Controls/InputNumber/InputNumber.tsx
+++ b/modules/shared/ui/Controls/InputNumber/InputNumber.tsx
@@ -6,14 +6,41 @@ type InputProps = React.ComponentProps<typeof Input> & {
   isInteger?: boolean
 }
 
-export function InputNumber({ value, onChange, ...props }: InputProps) {
+export function InputNumber({
+  value,
+  isInteger,
+  onChange,
+  ...props
+}: InputProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (isNaN(Number(e.target.value))) return
-      e.target.value = e.target.value.trim()
+      let eventValue = e.currentTarget.value.trim()
+
+      if (isNaN(Number(eventValue))) return
+
+      if (isInteger) {
+        if (eventValue.includes(',')) {
+          eventValue = eventValue.replaceAll(',', '')
+        }
+        if (eventValue.includes('.')) {
+          eventValue = eventValue.replaceAll('.', '')
+        }
+      } else {
+        // Support for devices where inputMode="decimal" showing keyboard with comma as decimal delimiter
+        if (eventValue.includes(',')) {
+          eventValue = eventValue.replaceAll(',', '.')
+        }
+
+        // Prepend zero when user types just a dot symbol for "0."
+        if (eventValue === '.') {
+          eventValue = '0.'
+        }
+      }
+
+      e.currentTarget.value = eventValue
       onChange?.(e)
     },
-    [onChange],
+    [isInteger, onChange],
   )
 
   return <Input value={value} onChange={handleChange} {...props} />

--- a/modules/votes/providers/VotePrompt/VotePromptProvider.tsx
+++ b/modules/votes/providers/VotePrompt/VotePromptProvider.tsx
@@ -15,6 +15,8 @@ export function VotePromptProvider({ children }: Props) {
   const [voteId, setVoteIdState] = useState(urlVoteId || '')
 
   const changeRouteInstantly = useCallback((value: string) => {
+    const _voteId = Router.query.voteId
+    if (_voteId === value || (!_voteId && !value)) return
     Router.push(value ? urls.vote(value) : urls.home, undefined, {
       scroll: false,
     })

--- a/modules/votes/ui/HeaderVoteInput/HeaderVoteInputStyle.ts
+++ b/modules/votes/ui/HeaderVoteInput/HeaderVoteInputStyle.ts
@@ -1,7 +1,9 @@
 import styled, { css } from 'styled-components'
 import { InputNumber } from 'modules/shared/ui/Controls/InputNumber'
 
-export const Input = styled(InputNumber)`
+export const Input = styled(InputNumber).attrs({
+  isInteger: true,
+})`
   height: 44px;
 
   & > span {


### PR DESCRIPTION
### Description

When enter an empty request in the voting number input field, then error 404 is returned

### Testing notes

Steps to reproduce:
- Go to [https://vote.lido.fi](https://vote.lido.fi/vote)
- Click to voting number input field
- Press Enter

Expected result: Nothing will be changed whether, when enters an empty request in the voting number input field. Error 404 isn't returned.
Actual result: When enter an empty request in the voting number input field, then https://vote.lido.fi/vote opens and error 404 is returned. 
Reproducibility: always

Environment & Configuration:
- Operating system: any
- Web browser: any
- Wallets: not needed
- Workaround: No

### Checklist:

- [x]  Checked the changes locally.
