### PR TITLE
Feature/si 811 dao voting the first symbol of voting number isnt removed on

### DIFF
--- a/modules/votes/providers/VotePrompt/VotePromptProvider.tsx
+++ b/modules/votes/providers/VotePrompt/VotePromptProvider.tsx
@@ -34,8 +34,8 @@ export function VotePromptProvider({ children }: Props) {
   )
 
   const clearVoteId = useCallback(() => {
-    changeRouteInstantly('')
-  }, [changeRouteInstantly])
+    setVoteId('')
+  }, [setVoteId])
 
   useEffect(() => {
     setVoteIdState(urlVoteId || '')


### PR DESCRIPTION
### Description

The first symbol of voting number isn't removed on the first try in the voting number input field when erasing voting number. 

For example, if remove all symbols from input field, then number 1 will be displayed again and the first voting card will be loaded

### Testing notes

Steps to reproduce:
- Go to https://vote.lido.fi/ 
- Enter any voting number in the voting number input field
- Erase the voting number from the voting number input field


Expected result: The first symbol of voting number is removed on the first try when erasing voting number in the voting number input field
Actual result:The first symbol of voting number isn't removed on the first try when erasing voting number in the voting number input field
Reproducibility: always

Environment & Configuration:
- Operating system: any
- Web browser: any
- Workaround: Yes

### Checklist:

- [x]  Checked the changes locally.
