### PR TITLE
fix: hide wallets that appear after sdk update

### DIFF
--- a/modules/wallet/ui/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/modules/wallet/ui/ConnectWalletModal/ConnectWalletModal.tsx
@@ -21,6 +21,11 @@ const HIDDEN_WALLETS: WalletModalForEthProps['hiddenWallets'] = [
   'tally',
   'zengo',
   'zerion',
+  'bitget',
+  'bitkeep',
+  'taho',
+  'coin',
+  'coin98',
 ]
 
 type Props = WalletModalForEthProps & {}


### PR DESCRIPTION
### Description
hide wallets form connection list bitget, bitkeep, taho, coin, coin98

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
