### PR TITLE
feat: add support holesky for WalletConnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ To create a new release:
 1. When you need to release, go to Repo → Releases.
 1. Publish the desired release draft manually by clicking the edit button - this release is now the `Latest Published`.
 1. After publication, the action to create a release bump will be triggered automatically.
+1.

--- a/modules/wagmiConfig/appWagmiConfig.tsx
+++ b/modules/wagmiConfig/appWagmiConfig.tsx
@@ -7,6 +7,32 @@ import getConfig from 'next/config'
 import { getRpcUrlDefault } from 'modules/config'
 import { CHAINS } from '@lido-sdk/constants'
 
+export const holesky = {
+  id: CHAINS.Holesky,
+  name: 'Holesky',
+  network: 'holesky',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'holeskyETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: { http: [getRpcUrlDefault(CHAINS.Holesky)] },
+    default: { http: [getRpcUrlDefault(CHAINS.Holesky)] },
+  },
+  blockExplorers: {
+    etherscan: { name: 'holesky', url: 'https://holesky.etherscan.io/' },
+    default: { name: 'holesky', url: 'https://holesky.etherscan.io/' },
+  },
+  testnet: true,
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 77,
+    },
+  },
+} as const
+
 const { publicRuntimeConfig } = getConfig()
 
 let supportedChainIds: number[] = []
@@ -19,7 +45,10 @@ if (publicRuntimeConfig.supportedChains != null) {
   supportedChainIds = [parseInt(publicRuntimeConfig.defaultChain)]
 }
 
-const wagmiChainsArray = Object.values(wagmiChains)
+const wagmiChainsArray = Object.values({
+  ...wagmiChains,
+  [CHAINS.Holesky]: holesky,
+})
 const supportedChains = wagmiChainsArray.filter(
   chain =>
     // Temporary wagmi fix, need to hardcode it to not affect non-wagmi wallets


### PR DESCRIPTION
### Description

User can connect WalletConnect at holesky

### Testing notes

safe app url - https://stg.holesky-safe.protofire.io

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
