### PR TITLE
feat(Vercel): add Vercel deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ The required functionality includes:
 
 [More details](https://www.notion.so/Custom-voting-UI-feature-description-bde7fde42d3749a3afcbab3a56f26674)
 
+## Deploy to Vercel
+
+Using the deployment button below, you can create your own version of the Voting UI on [Vercel](https://vercel.com/)
+
+Please, click on "Deploy" and follow the Vercel instructions.
+
+To deploy the app, you will need to set the following two required environment variables:
+
+1. `ETHERSCAN_API_KEY`: Your Etherscan API key.
+2. `VERCEL_MAINNET_RPC_URLS`: A comma-separated list of preferred Mainnet RPC URLs (e.g., URL1,URL2,URL3,...); The first entry is primary, else are fallbacks.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/lidofinance/dao-voting-ui&env=ETHERSCAN_API_KEY,VERCEL_MAINNET_RPC_URLS&project-name=lido-voting-ui&repository-name=lido-voting-ui)
+
+Note: If the GitHub account attached to Vercel is a part of any GitHub organization, the Vercel "Pro" subscription plan might be required.
+
 ## Pre-requisites
 
 - Node.js v12+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,10 @@
 const basePath = process.env.BASE_PATH || ''
 
+
+// The VERCEL_MAINNET_RPC_URLS gets from the Vercel deploy
 const rpcUrls_1 =
-  process.env.EL_RPC_URLS_1 && process.env.EL_RPC_URLS_1.split(',')
+  (process.env.EL_RPC_URLS_1 && process.env.EL_RPC_URLS_1.split(',')) ||
+  (process.env.VERCEL_MAINNET_RPC_URLS && process.env.VERCEL_MAINNET_RPC_URLS.split(','))
 const rpcUrls_5 =
   process.env.EL_RPC_URLS_5 && process.env.EL_RPC_URLS_5.split(',')
 const rpcUrls_17000 =
@@ -9,8 +12,14 @@ const rpcUrls_17000 =
 
 const etherscanApiKey = process.env.ETHERSCAN_API_KEY
 
-const defaultChain = process.env.DEFAULT_CHAIN || '17000'
-const supportedChains = process.env.SUPPORTED_CHAINS || '17000'
+// Mainnet is the default chain
+const _defaultChain =  '1';
+
+// Keep both Mainnet and Holesky as defaults
+const _defaultSupportedChains = '1,17000'
+
+const defaultChain = process.env.DEFAULT_CHAIN || _defaultChain
+const supportedChains = process.env.SUPPORTED_CHAINS || _defaultSupportedChains
 
 const cspTrustedHosts = process.env.CSP_TRUSTED_HOSTS
 const cspReportOnly = process.env.CSP_REPORT_ONLY


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Add a "Deploy to Vercel" section and a deployment button to the README.md.

This button allows everyone to deploy their own version of the Voting UI using Vercel.

Docs on [Vercel](https://vercel.com/docs/deployments/deploy-button)

NOTE: The `WALLETCONNECT_PROJECT_ID` environment variable is missing for the Vercel deployment; we will mention it in the docs and the README file.

<!--- Briefly note most valuable changes in what you did and why we need it, even if the task was described in detail in the task tracker. -->

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

New section:

![image](https://github.com/user-attachments/assets/8c2f7a9a-c8c4-46da-9216-6982f7a65c1e)

Vercel deploy UI:

![vercel com_new_phonktowns-projects_clone_repository-url=https%3A%2F%2Fgithub com%2Flidofinance%2Fdao-voting-ui env=env%3DETHERSCAN_API_KEY%2CMAINNET_RPC_URLS project-name=lido-voting-ui repository-name=lido-voting-u](https://github.com/user-attachments/assets/966afd2f-1be5-44e2-aa13-027014a801df)


### Code review notes

A new environment variable was created for use via Vercel deploy: MAINNET_RPC_URLS.

We now also check if this variable is present before assigning the default chain and supported chains in case no ENVs were passed.

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

A fork was created for testing purposes, as Vercel clones the default Git branch while deploying, which is develop in this case.

[Fork diff](https://github.com/lidofinance/dao-voting-ui/compare/develop...phonktown:dao-voting-ui:develop)

The changes in this PR and in the fork are identical, but there are 2 differences:

1. The changes in the fork are already in the develop branch, thus we can test the deployment itself.
2. The button links are different, based on lidofinance/ and phonktown/ repo URLs accordingly.

When review/QA passes, we need to merge this branch into `develop` and check the deployment.

QA Vercel: 
- Clicking on the "Deploy" button from the README file should lead to the Vercel website with the deployment form.
- The default project name is "lido-voting-ui."
- The Git scope is the GitHub account connected to Vercel.
- After clicking on the 'Create' button in the first section, the next section called "Configure Project" should become active.
- Please fill in 2 ENV variables (ETHERSCAN_API_KEY, MAINNET_RPC_URLS) and click on "Deploy."
- A deployment should start.
- When the deployment is done, we should see the app preview.
- If the ENV vars were filled properly, after clicking on the preview, we should see a working app configured to work on the Mainnet.

QA Voting UI
As we added a new ENV variable, it's worth checking that the app works as before regarding default and supported chains (this was tested locally during development):

- If we deploy the app on the testnet, it works on Holesky by default.
- If we deploy the app on the mainnet, it works on the Mainnet by default.
- If we provide both MAINNET_RPC_URLS and EL_RPC_URLS_1 ENVs, the latter is used by default.
- ...


[Fork](https://github.com/phonktown/dao-voting-ui)

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
