### PR TITLE
feat: force fallback request on popular rpc issues

### DIFF
--- a/modules/network/utils/fetchWithFallback.ts
+++ b/modules/network/utils/fetchWithFallback.ts
@@ -21,9 +21,15 @@ export const fetchWithFallback: FetchWithFallback = async (
       .startTimer()
     const response = await fetch(input, init)
     end()
+    if (!response.ok) {
+      // try fallback, 4xx mostly related with token limits or etc.
+      const text = await response.text()
+      throw new Error(`Request failed status ${response.status} ${text}`)
+    }
     return response
   } catch (error) {
     if (!restInputs.length) throw error
+    console.error(error)
     return fetchWithFallback(restInputs, chainId, init)
   }
 }

--- a/modules/network/utils/fetchWithFallback.ts
+++ b/modules/network/utils/fetchWithFallback.ts
@@ -13,7 +13,7 @@ export const fetchWithFallback: FetchWithFallback = async (
   init,
 ) => {
   const [input, ...restInputs] = inputs
-
+  const hasFallback = Boolean(restInputs.length)
   try {
     const url = new URL(input as string)
     const end = rpcResponseTime
@@ -21,14 +21,16 @@ export const fetchWithFallback: FetchWithFallback = async (
       .startTimer()
     const response = await fetch(input, init)
     end()
-    if (!response.ok) {
+
+    if (!response.ok && hasFallback) {
       // try fallback, 4xx mostly related with token limits or etc.
       const text = await response.text()
       throw new Error(`Request failed status ${response.status} ${text}`)
     }
+
     return response
   } catch (error) {
-    if (!restInputs.length) throw error
+    if (!hasFallback) throw error
     console.error(error)
     return fetchWithFallback(restInputs, chainId, init)
   }


### PR DESCRIPTION
extra cases for fallback:
- 4xx 
- wrong event list in getLogs requests
- empty event list in getLogs requests
- error in getLogs requests

### Testing notes

The changes affect all rpc requests

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
