### PR TITLE
refactor: voting time display

### DIFF
--- a/modules/dashboard/ui/DashboardGrid/DashboardGrid.tsx
+++ b/modules/dashboard/ui/DashboardGrid/DashboardGrid.tsx
@@ -13,6 +13,7 @@ import { ContractVoting } from 'modules/blockChain/contracts'
 import { getVoteStatus } from 'modules/votes/utils/getVoteStatus'
 import { getEventStartVote } from 'modules/votes/utils/getEventVoteStart'
 import * as urls from 'modules/network/utils/urls'
+import { getEventExecuteVote } from 'modules/votes/utils/getEventExecuteVote'
 
 const PAGE_SIZE = 20
 
@@ -71,19 +72,26 @@ export function DashboardGrid({ currentPage }: Props) {
 
       const votesList = await Promise.all(requests)
 
-      const eventsPromises = votesList.map(dataItem => {
-        const fetch = async () => {
-          const eventStart = await getEventStartVote(
-            contractVoting,
-            dataItem.voteId,
-            dataItem.vote.snapshotBlock.toNumber(),
-          )
-          return {
-            ...dataItem,
-            eventStart,
-          }
+      const eventsPromises = votesList.map(async dataItem => {
+        const snapshotBlock = dataItem.vote.snapshotBlock.toNumber()
+        const eventStart = await getEventStartVote(
+          contractVoting,
+          dataItem.voteId,
+          snapshotBlock,
+        )
+        const eventExecute = await getEventExecuteVote(
+          contractVoting,
+          dataItem.voteId,
+          snapshotBlock,
+        )
+        const executeBlock = await eventExecute?.event.getBlock()
+
+        const executedAt = executeBlock?.timestamp ?? null
+        return {
+          ...dataItem,
+          eventStart,
+          executedAt,
         }
-        return fetch()
       })
 
       const votesWithEvents = await Promise.all(eventsPromises)

--- a/modules/dashboard/ui/DashboardGrid/DashboardGrid.tsx
+++ b/modules/dashboard/ui/DashboardGrid/DashboardGrid.tsx
@@ -84,13 +84,11 @@ export function DashboardGrid({ currentPage }: Props) {
           dataItem.voteId,
           snapshotBlock,
         )
-        const executeBlock = await eventExecute?.event.getBlock()
 
-        const executedAt = executeBlock?.timestamp ?? null
         return {
           ...dataItem,
           eventStart,
-          executedAt,
+          executedAt: eventExecute?.executedAt,
         }
       })
 

--- a/modules/dashboard/ui/DashboardVote/DashboardVote.tsx
+++ b/modules/dashboard/ui/DashboardVote/DashboardVote.tsx
@@ -30,6 +30,7 @@ type Props = {
   status: VoteStatus
   voteTime: number
   objectionPhaseTime: number
+  executedAt: number | null
   onPass: () => void
 }
 
@@ -40,6 +41,7 @@ export function DashboardVote({
   status,
   voteTime,
   objectionPhaseTime,
+  executedAt,
   onPass,
 }: Props) {
   const {
@@ -51,9 +53,8 @@ export function DashboardVote({
     nayPctOfTotalSupplyFormatted,
     yeaPctOfTotalSupplyFormatted,
     startDate,
-    endDate,
     totalSupply,
-  } = getVoteDetailsFormatted({ vote, voteTime })
+  } = getVoteDetailsFormatted(vote)
 
   const handlePass = useCallback(() => {
     // TODO:
@@ -88,7 +89,7 @@ export function DashboardVote({
       <Wrap data-testid={`voteCardPreview-${voteId}`}>
         <VoteStatusBanner
           startDate={startDate}
-          endDate={endDate}
+          executedAt={executedAt}
           voteTime={voteTime}
           objectionPhaseTime={objectionPhaseTime}
           status={status}

--- a/modules/dashboard/ui/DashboardVote/DashboardVote.tsx
+++ b/modules/dashboard/ui/DashboardVote/DashboardVote.tsx
@@ -26,11 +26,11 @@ import * as urls from 'modules/network/utils/urls'
 type Props = {
   voteId: number
   vote: Vote
-  eventStart: StartVoteEventObject | null
+  eventStart: { decoded: StartVoteEventObject } | null
   status: VoteStatus
   voteTime: number
   objectionPhaseTime: number
-  executedAt: number | null
+  executedAt?: number
   onPass: () => void
 }
 
@@ -103,7 +103,7 @@ export function DashboardVote({
         <VoteBody>
           <VoteTitle>Vote #{voteId}</VoteTitle>
           <VoteDescriptionWrap data-testid="voteDescription">
-            <VoteDescription metadata={eventStart?.metadata} />
+            <VoteDescription metadata={eventStart?.decoded.metadata} />
           </VoteDescriptionWrap>
         </VoteBody>
         <Footer>

--- a/modules/votes/ui/VoteDetails/VoteDetailsStyle.ts
+++ b/modules/votes/ui/VoteDetails/VoteDetailsStyle.ts
@@ -62,3 +62,9 @@ export const VoteHeader = styled.div`
 export const BlockWrap = styled.div`
   text-align: right;
 `
+
+export const VoteTimestamps = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`

--- a/modules/votes/ui/VoteForm/VoteForm.tsx
+++ b/modules/votes/ui/VoteForm/VoteForm.tsx
@@ -116,11 +116,13 @@ export function VoteForm({ voteId }: Props) {
             voteTime={voteTime!}
             objectionPhaseTime={objectionPhaseTime!}
             isEnded={isEnded}
-            metadata={eventStart?.metadata}
+            metadata={eventStart?.decoded.metadata}
             eventsVoted={eventsVoted}
             eventsDelegatesVoted={eventsDelegatesVoted}
             executedTxHash={eventExecuteVote?.event.transactionHash}
+            executedAt={eventExecuteVote?.executedAt}
             votePhase={votePhase}
+            startedTxHash={eventStart?.event.transactionHash}
           />
 
           {!isWalletConnected && votePhase !== VotePhase.Closed && (

--- a/modules/votes/ui/VoteProgressBar/VoteProgressBar.tsx
+++ b/modules/votes/ui/VoteProgressBar/VoteProgressBar.tsx
@@ -15,7 +15,6 @@ import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
   startDate: number
-  endDate: number
   voteTime: number
   objectionPhaseTime: number
   isEnded: boolean
@@ -24,7 +23,6 @@ interface Props {
 
 export function VoteProgressBar({
   startDate,
-  endDate,
   voteTime,
   objectionPhaseTime,
   isEnded,
@@ -84,7 +82,10 @@ export function VoteProgressBar({
   }
 
   const formattedStartDate = useMemo(() => formatDate(startDate), [startDate])
-  const formattedEndDate = useMemo(() => formatDate(endDate), [endDate])
+  const formattedEndDate = useMemo(() => {
+    const endDate = startDate + voteTime
+    return formatDate(endDate)
+  }, [startDate, voteTime])
 
   return (
     <>

--- a/modules/votes/ui/VoteStatusBanner/VoteStatusBanner.tsx
+++ b/modules/votes/ui/VoteStatusBanner/VoteStatusBanner.tsx
@@ -18,7 +18,7 @@ import { convertStatusToStyledVariant, VoteStatusFontSize } from './types'
 
 type Props = {
   startDate: number
-  endDate: number
+  executedAt: number | null
   voteTime: number
   objectionPhaseTime: number
   isEnded: boolean
@@ -32,7 +32,7 @@ type Props = {
 
 export function VoteStatusBanner({
   startDate,
-  endDate,
+  executedAt,
   voteTime,
   objectionPhaseTime,
   isEnded,
@@ -56,11 +56,11 @@ export function VoteStatusBanner({
     return yeaQuorum > minAcceptQuorum || nayQuorum > minAcceptQuorum
   }, [totalSupply, yeaNum, nayNum, minAcceptQuorum])
 
-  const endDateEl = (
+  const endDateEl = executedAt ? (
     <InfoText variant={variant}>
-      <FormattedDate date={endDate} format="DD MMM YYYY, HH:mm" />
+      <FormattedDate date={executedAt} format="DD MMM YYYY" />
     </InfoText>
-  )
+  ) : null
 
   return (
     <Wrap data-testid="voteCardHeader" fontSize={fontSize} variant={variant}>
@@ -98,7 +98,6 @@ export function VoteStatusBanner({
             <DoneIconSVG />
           </BadgePassed>
           <BannerText variant={variant}>Passed (pending)</BannerText>
-          {endDateEl}
         </>
       )}
 
@@ -128,7 +127,6 @@ export function VoteStatusBanner({
             <ClearIconSVG />
           </BadgeFailed>
           <BannerText variant={variant}>Rejected</BannerText>
-          {endDateEl}
         </>
       )}
 
@@ -138,7 +136,6 @@ export function VoteStatusBanner({
             <ClearIconSVG />
           </BadgeNoQuorum>
           <BannerText variant={variant}>No quorum</BannerText>
-          {endDateEl}
         </>
       )}
     </Wrap>

--- a/modules/votes/ui/VoteStatusBanner/VoteStatusBanner.tsx
+++ b/modules/votes/ui/VoteStatusBanner/VoteStatusBanner.tsx
@@ -18,7 +18,7 @@ import { convertStatusToStyledVariant, VoteStatusFontSize } from './types'
 
 type Props = {
   startDate: number
-  executedAt: number | null
+  executedAt: number | undefined
   voteTime: number
   objectionPhaseTime: number
   isEnded: boolean

--- a/modules/votes/utils/getEventExecuteVote.ts
+++ b/modules/votes/utils/getEventExecuteVote.ts
@@ -11,6 +11,7 @@ export async function getEventExecuteVote(
 ): Promise<{
   event: ExecuteVoteEvent
   decoded: ExecuteVoteEventObject
+  executedAt: number | undefined
 } | null> {
   const filter = contractVoting.filters.ExecuteVote(Number(voteId))
   const events = await contractVoting.queryFilter(
@@ -22,8 +23,18 @@ export async function getEventExecuteVote(
   }
   const event = events[0]
 
+  let executedAt: number | undefined
+
+  try {
+    const executeBlock = await event.getBlock()
+    executedAt = executeBlock.timestamp
+  } catch (error) {
+    console.error('Failed to get block for ExecuteVote event', error)
+  }
+
   return {
     event,
     decoded: event.args,
+    executedAt,
   }
 }

--- a/modules/votes/utils/getEventVoteStart.ts
+++ b/modules/votes/utils/getEventVoteStart.ts
@@ -1,5 +1,6 @@
 import type {
   AragonVotingAbi,
+  StartVoteEvent,
   StartVoteEventObject,
 } from 'generated/AragonVotingAbi'
 
@@ -7,7 +8,10 @@ export async function getEventStartVote(
   contractVoting: AragonVotingAbi,
   voteId: string | number,
   block?: string | number,
-): Promise<StartVoteEventObject | null> {
+): Promise<{
+  event: StartVoteEvent
+  decoded: StartVoteEventObject
+} | null> {
   const filter = contractVoting.filters.StartVote(Number(voteId))
   const events = await contractVoting.queryFilter(
     filter,
@@ -19,5 +23,10 @@ export async function getEventStartVote(
     return null
   }
 
-  return events[0].args
+  const event = events[0]
+
+  return {
+    event,
+    decoded: event.args,
+  }
 }

--- a/modules/votes/utils/getVoteDetailsFormatted.ts
+++ b/modules/votes/utils/getVoteDetailsFormatted.ts
@@ -3,12 +3,7 @@ import { weiToNum } from 'modules/blockChain/utils/parseWei'
 import { formatFloatPct } from 'modules/shared/utils/formatFloatPct'
 import { formatNumber } from 'modules/shared/utils/formatNumber'
 
-type Args = {
-  vote: Vote
-  voteTime: number
-}
-
-export function getVoteDetailsFormatted({ vote, voteTime }: Args) {
+export function getVoteDetailsFormatted(vote: Vote) {
   const totalSupply = weiToNum(vote.votingPower)
   const totalSupplyFormatted = formatNumber(totalSupply, 4)
   const nayNum = weiToNum(vote.nay)
@@ -29,7 +24,6 @@ export function getVoteDetailsFormatted({ vote, voteTime }: Args) {
     : 0
 
   const startDate = vote.startDate.toNumber()
-  const endDate = startDate + voteTime
 
   return {
     totalSupply,
@@ -43,6 +37,5 @@ export function getVoteDetailsFormatted({ vote, voteTime }: Args) {
     nayPctOfTotalSupplyFormatted,
     yeaPctOfTotalSupplyFormatted,
     startDate,
-    endDate,
   }
 }


### PR DESCRIPTION
### Context

Vote [#184](https://vote.lido.fi/vote/184) has changed the voting and objection time values. This update reflects on those values being changed in Voting contract.

### Changelog

- Vote card: show enact time from enact event. Hide time, show only date. Remove date from rejected/no quorum votes;
- Vote page: show timestamp from enact event if enacted, vote start time otherwise;
- Vote page: add link to start tx on block number label.