### PR TITLE
feat: add testIds to account and DG widget

### DIFF
--- a/modules/dual-governance/DualGovernanceStatusButton/DualGovernanceStatusButton.tsx
+++ b/modules/dual-governance/DualGovernanceStatusButton/DualGovernanceStatusButton.tsx
@@ -28,7 +28,7 @@ export const DualGovernanceStatusButton = () => {
         onClick={handleButtonClick}
         ref={anchorRef}
         icon={initialLoading ? <Loader /> : DGIcon}
-        data-testid={`dgBtn`}
+        data-testid="dgBtn"
       />
       {!!data && (
         <PopoverStyled

--- a/modules/dual-governance/DualGovernanceWidget/DualGovernanceWidget.tsx
+++ b/modules/dual-governance/DualGovernanceWidget/DualGovernanceWidget.tsx
@@ -94,21 +94,21 @@ export const DualGovernanceWidget = ({ dualGovernanceState }: Props) => {
       status === DualGovernanceStatus.VetoCooldown)
 
   return (
-    <DualGovernanceWidgetWrapper data-testid={`dgWidget`}>
+    <DualGovernanceWidgetWrapper data-testid="dgWidget">
       {/* Governance State */}
       <p>
         <Label $size={14} $weight={700}>
           Governance
         </Label>
-        <Label data-testid={`dgStatus`}>
-          <StatusBulb $status={status} data-testid={`statusBulb`} />
+        <Label data-testid="dgStatus">
+          <StatusBulb $status={status} data-testid="statusBulb" />
           {getDualGovernanceStatusLabel(status)}
         </Label>
       </p>
       {showState && (
         <p>
           <Label>State</Label>
-          <Label data-testid={`dgState`}>
+          <Label data-testid="dgState">
             {stringifyDualGovernanceStatus(status)}
           </Label>
         </p>
@@ -118,7 +118,7 @@ export const DualGovernanceWidget = ({ dualGovernanceState }: Props) => {
         <Box display="flex" justifyContent="space-between">
           <Label>Veto Support</Label>
           <p>
-            <Label $color="secondary" data-testid={`vsBalance`}>
+            <Label $color="secondary" data-testid="vsBalance">
               {formatBalance(totalStEthInEscrow, 1)} /{' '}
               {formatBalance(totalSupply, 1)}
             </Label>
@@ -130,7 +130,7 @@ export const DualGovernanceWidget = ({ dualGovernanceState }: Props) => {
         <Box display="flex" justifyContent="space-between">
           <Label>RageQuit threshold</Label>
           <p>
-            <Label $color="secondary" data-testid={`rqPercent`}>
+            <Label $color="secondary" data-testid="rqPercent">
               {formattedRageQuitThresholdPercent}%
             </Label>
           </p>
@@ -140,8 +140,7 @@ export const DualGovernanceWidget = ({ dualGovernanceState }: Props) => {
       {showNextState && (
         <p>
           <Label>Next state</Label>
-          <Label data-testid={`nextState`}>
-            {' '}
+          <Label data-testid="nextState">
             {stringifyDualGovernanceStatus(nextStatus)}
           </Label>
         </p>
@@ -178,7 +177,7 @@ export const DualGovernanceWidget = ({ dualGovernanceState }: Props) => {
         href={getDualGovernanceLink(chainId)}
         target="_blank"
         rel="noreferrer"
-        data-testid={`dgRedirectBtn`}
+        data-testid="dgRedirectBtn"
       >
         Go to Dual Governance
       </CheckLink>

--- a/modules/wallet/ui/WalletModal/WalletModal.tsx
+++ b/modules/wallet/ui/WalletModal/WalletModal.tsx
@@ -38,7 +38,7 @@ function WalletModalContent() {
           children={initialLoading ? 'Loading...' : 'Balance'}
         />
         {tokenData?.balanceStr ? (
-          <Text size="xxs" weight={500} data-testid={`balance`}>
+          <Text size="xxs" weight={500} data-testid="balance">
             &nbsp;
             {tokenData.balanceStr}
           </Text>
@@ -47,7 +47,7 @@ function WalletModalContent() {
 
       <Row>
         <Identicon address={walletAddress ?? ''} />
-        <Address data-testid={`walletAddress`}>{trimmedAddress}</Address>
+        <Address data-testid="walletAddress">{trimmedAddress}</Address>
       </Row>
 
       <Row>


### PR DESCRIPTION
### Description

This PR adds **testIds** to improve the testing and automation process for the UI elements.

The following **testIds** have been added:

**Account Window:**

- `Balance`
- `Wallet address`

**DG Widget:**

- `DG button on header`
- `DG widget`
- `DG state`
- `DG status`
- `Status bulb`
- `Veto support balance`
- `DG redirection button in widget`
- `Rage quit threshold percent`
- `DG next state`