### PR TITLE
fix: trim ipfs \x00 symbol

### DIFF
--- a/modules/network/utils/fetcherIPFS.ts
+++ b/modules/network/utils/fetcherIPFS.ts
@@ -27,7 +27,8 @@ export const fetcherIPFS: FetcherIPFS = async (
     throw new Error('An error occurred while fetching the data.')
   }
 
-  const text = await response.text()
+  const textRaw = await response.text()
+  const text = textRaw.replaceAll('\x00', '')
 
   const [hash, hashBOM] = await Promise.all([
     Hash.of(text, { cidVersion: 1, rawLeaves: true }),


### PR DESCRIPTION
### Description

fix ipfs response with `\x00` ending at [vote 169](https://vote.lido.fi/vote/169)

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
